### PR TITLE
fix / client - fixed window.location.href

### DIFF
--- a/client/components/App.jsx
+++ b/client/components/App.jsx
@@ -34,7 +34,7 @@ export default function App() {
 				axios.post('/user/logout')
 					.then((response) => {
 						if (response.status === 200){
-							window.location.href = "http://localhost:8080/";
+							window.location.href = "http://ec2-3-129-61-157.us-east-2.compute.amazonaws.com:8080/";
 						}
 					})
 					.catch((error) => {
@@ -74,7 +74,7 @@ export default function App() {
 					axios.delete('/user/delete')
 						.then((response) => {
 							if (response.status === 200){
-								window.location.href = "http://localhost:8080/";
+								window.location.href = "http://ec2-3-129-61-157.us-east-2.compute.amazonaws.com:8080/";
 							}
 						})
 						.catch((error) => {


### PR DESCRIPTION
Changed href in client so that it redirects correctly on user sign-out. A current issue exists where you _might_ be automatically logged back into the website after a sign-out.

This issue originates from how Google Passport works; because you gave consent and have signed into the website previously it will automatically attempt to sign you in again (to my understanding). A possible fix to this is to force consent form at the sign-in page.